### PR TITLE
Add farmOS.py as a source repo.

### DIFF
--- a/source-repos.js
+++ b/source-repos.js
@@ -17,4 +17,13 @@ module.exports = [
     branch: 'main',
     directory: 'docs/',
   },
+  {
+    name: 'farmOS.py',
+    title: 'farmOS.py Docs',
+    baseURI: '/docs/python',
+    mkdocs: 'docs/config.yml',
+    remote: 'https://github.com/farmOS/farmOS.py.git',
+    branch: '1.x',
+    directory: 'docs/',
+  },
 ];


### PR DESCRIPTION
As requested, this adds farmOS.py as a source repo! #17 

I also updated farmOS.py to include the netlify workflow to hit the build hook: https://github.com/farmOS/farmOS.py/blob/1.x/.github/workflows/netlify-build-docs.yml

@jgaehring I was able to make a few simplifications to how the `TRIGGER_TITLE` and `TRIGGER_BRANCH` env vars were made. I believe this ran once and worked! https://github.com/farmOS/farmOS.py/runs/4489280997?check_suite_focus=true