### PR TITLE
Render a link to source repo

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -80,6 +80,13 @@ exports.createPages = async ({ graphql, actions }) => {
               pathname
               sourceInstanceName
             }
+            parent {
+              ... on File {
+                gitRemote {
+                  webLink
+                }
+              }
+            }
           }
         }
       }
@@ -94,6 +101,7 @@ exports.createPages = async ({ graphql, actions }) => {
         // in page queries as GraphQL variables.
         pathname: node.fields.pathname,
         sourceInstanceName: node.fields.sourceInstanceName,
+        sourceLink: node?.parent?.gitRemote?.webLink
       },
     });
   });

--- a/src/components/table-of-contents.js
+++ b/src/components/table-of-contents.js
@@ -36,11 +36,16 @@ const useStyles = makeStyles(theme => ({
 
 export default function TableOfContents(props) {
   const classes = useStyles();
-  const { __html, headings, title = 'Table of contents' } = props;
+  const { __html, headings, source, title = 'Table of contents' } = props;
 
   const [tocRef, setActiveHeading] = useActiveHeading(headings, classes.active);
 
   return (<>
+    <h3>
+        <a href={source.sourceLink} style={{ textDecoration: 'none' }}>
+          {source.sourceInstanceName} source
+        </a>
+    </h3>
     <Typography component='label' className={classes.title}>{title}</Typography>
     <Box
       ref={tocRef}

--- a/src/templates/docs-page.js
+++ b/src/templates/docs-page.js
@@ -31,13 +31,18 @@ const useStyles = makeStyles({
   },
 });
 
-export default function DocsPage({ data }) {
+export default function DocsPage({ data, pageContext }) {
   const classes = useStyles();
 
   const { markdownRemark: post } = data;
+  const { sourceInstanceName, sourceLink } = pageContext;
   const [tocHtml, setTocHtml] = useState(post.tableOfContents);
   const title = post.headings.find(({ depth }) => depth === 1)?.value;
   const toc = {
+    source: {
+      sourceInstanceName,
+      sourceLink,
+    },
     title,
     __html: tocHtml,
     headings: post.headings


### PR DESCRIPTION
This needs to ironed out a bit more, but opening a PR to see if this is going in the right direction.

I noticed that the `gatsby-source-git` plugin adds a `gitRemote` field with different bits of data, including a `webLink`. I think that could work well here! As mentioned in their docs, this might help to implement an "edit on github" link as well: https://www.gatsbyjs.com/plugins/gatsby-source-git/

For demonstration I put the source link about the table of contents. This seems like a natural area to include the source link (and maybe the source version??) but open to ideas! This mostly fulfilled the exercise of "I want to put a link here, how do I do that" and to help learn how some of these things are working

I'm also not sure how this React markup works.. I'm sure there's a better way to render a stylized link here... but I guess maybe we want the Github icon prefixed as well... so perhaps this could be its own component? Maybe one already exists?