### PR TITLE
Add redirects for v1.farmos.org and docs.farmos.org.

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,23 @@
+# Redirect all docs.farmOS.org traffic to farmOS.org.
+http://docs.farmos.org/* https://farmos.org/:splat 301
+https://docs.farmos.org/* https://farmos.org/:splat 301
+
+# Redirect legacy paths to v1.farmOS.org.
+/community/contribute/ https://v1.farmos.org/community/contribute/ 301
+/community/farms/ https://v1.farmos.org/community/farms/ 301
+/development/architecture/ https://v1.farmos.org/development/architecture/ 301
+/development/client/ https://v1.farmos.org/development/client/ 301
+/development/docker/ https://v1.farmos.org/development/docker/ 301
+/development/drupal/ https://v1.farmos.org/development/drupal/ 301
+/development/projects/ https://v1.farmos.org/development/projects/ 301
+/development/release/ https://v1.farmos.org/development/release/ 301
+/development/update-safety/ https://v1.farmos.org/development/update-safety/ 301
+/faq/ https://v1.farmos.org/faq/ 301
+/hosting/apikeys/ https://v1.farmos.org/hosting/apikeys/ 301
+/hosting/docker/ https://v1.farmos.org/hosting/docker/ 301
+/hosting/installing/ https://v1.farmos.org/hosting/installing/ 301
+/hosting/localization/ https://v1.farmos.org/hosting/localization/ 301
+/hosting/updating/ https://v1.farmos.org/hosting/updating/ 301
+
+# Temporarily redirect the user guide (until v2 guide is available).
+/guide/* https://v1.farmos.org/guide/:splat 302


### PR DESCRIPTION
Here's a first pass - I think it covers everything we need.

Two main pieces:

- Redirects any requests that come in for `docs.farmos.org/*` to `farmos.org/*`, since we are essentially shutting down https://docs.farmos.org and sending visitors here instead.
- Redirects specific v1 paths that are no longer represented to https://v1.farmos.org - I went through all the pages in the main navigation (built from `mkdocs.yml`) and plugged them into the new domain to see if it `404`'d or not.

Note: I included a *temporary* (`302`) redirect for `/guide/*` => `https://v1.farmos.org/guide/*`. The thought is we can remove that if/when a new `/guide/` section is created.